### PR TITLE
Add frameless back on mac

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,7 +1,18 @@
 import { app, Menu, BrowserWindow } from "electron";
 import setupMenu from "./menu";
+import os from "os";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
+
+function getWindowOptionsByPlatform() {
+  const platform = os.platform();
+  const MacOptions = {
+    frame: false,
+    titleBarStyle: "hiddenInset"
+  };
+
+  return platform === "darwin" ? MacOptions : {};
+}
 
 // Global reference to mainWindow
 // Necessary to prevent win from being garbage collected
@@ -9,10 +20,7 @@ let mainWindow;
 
 function createMainWindow() {
   // Construct new BrowserWindow
-  const window = new BrowserWindow({
-    //  frame: false,
-    //  titleBarStyle: "hiddenInset"
-  });
+  const window = new BrowserWindow(getWindowOptionsByPlatform());
 
   // Set url for `win`
   // points to `webpack-dev-server` in development


### PR DESCRIPTION
On mac computers, use frameless windows. Otherwise, don't have any special options.

