### PR TITLE
Fix json load bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "immutable": "^3.8.2",
     "immutable-props": "^1.1.0",
     "inline-style-prefixer": "^3.0.8",
-    "invariant": "^2.2.2",
     "isdev": "^1.0.1",
     "json-parse-safe": "^1.0.3",
     "knex": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -9,22 +9,14 @@
     "test": "cross-env NODE_ENV=test ./node_modules/.bin/jest",
     "dist": "yarn compile && electron-builder",
     "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null",
-    "db-down":
-      "node node_modules/db-migrate/bin/db-migrate down --config config/database.json",
-    "db-up":
-      "node node_modules/db-migrate/bin/db-migrate up --config config/database.json",
-    "db-reset":
-      "node node_modules/db-migrate/bin/db-migrate reset --config config/database.json",
-    "db-create-config":
-      "cross-env NODE_ENV=development babel-node scripts/create-db-config/create.js",
-    "db-migrate-create":
-      "node node_modules/db-migrate/bin/db-migrate create -e dev --config config/database.json",
-    "add-some-notes":
-      "cross-env NODE_ENV=development babel-node scripts/convert-notes/convert.js scripts/convert-notes/our_small_dataset.json",
-    "add-many-notes":
-      "cross-env NODE_ENV=development babel-node scripts/convert-notes/convert.js scripts/convert-notes/our_large_dataset.json",
-    "create-note":
-      "cross-env NODE_ENV=development babel-node scripts/create-note/create.js",
+    "db-down": "node node_modules/db-migrate/bin/db-migrate down --config config/database.json",
+    "db-up": "node node_modules/db-migrate/bin/db-migrate up --config config/database.json",
+    "db-reset": "node node_modules/db-migrate/bin/db-migrate reset --config config/database.json",
+    "db-create-config": "cross-env NODE_ENV=development babel-node scripts/create-db-config/create.js",
+    "db-migrate-create": "node node_modules/db-migrate/bin/db-migrate create -e dev --config config/database.json",
+    "add-some-notes": "cross-env NODE_ENV=development babel-node scripts/convert-notes/convert.js scripts/convert-notes/our_small_dataset.json",
+    "add-many-notes": "cross-env NODE_ENV=development babel-node scripts/convert-notes/convert.js scripts/convert-notes/our_large_dataset.json",
+    "create-note": "cross-env NODE_ENV=development babel-node scripts/create-note/create.js",
     "lint": "./node_modules/.bin/eslint src",
     "postinstall": "electron-builder install-app-deps",
     "snyk-protect": "snyk protect"
@@ -53,6 +45,7 @@
     "immutable": "^3.8.2",
     "immutable-props": "^1.1.0",
     "inline-style-prefixer": "^3.0.8",
+    "invariant": "^2.2.2",
     "isdev": "^1.0.1",
     "json-parse-safe": "^1.0.3",
     "knex": "^0.13.0",
@@ -116,15 +109,28 @@
   },
   "snyk": true,
   "jest": {
-    "setupFiles": ["raf/polyfill", "enzyme-react-16-adapter-setup"],
+    "setupFiles": [
+      "raf/polyfill",
+      "enzyme-react-16-adapter-setup"
+    ],
     "collectCoverage": true,
     "coverageDirectory": "<rootDir>/coverage",
-    "coveragePathIgnorePatterns": ["/node_modules/", "/templates/", "/dist/"],
-    "testPathIgnorePatterns": ["/node_modules/", "/templates/", "/dist/"],
-    "coverageReporters": ["text", "lcov"],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/templates/",
+      "/dist/"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/templates/",
+      "/dist/"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-        "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "identity-obj-proxy"
     }
   }

--- a/src/lib/editor/util.js
+++ b/src/lib/editor/util.js
@@ -13,9 +13,17 @@ const editorStateFromText = text =>
 
 const emptyEditorState = () => EditorState.createEmpty();
 
-const noteWithEmptyEditor = () => {
-  const content = serializeContent(emptyEditorState());
-  return new NoteModel(content, EDITOR_NAME, [], []);
+const emptySerializedEditorState = () => {
+  return serializeContent(emptyEditorState());
 };
 
-export { editorStateFromText, emptyEditorState, noteWithEmptyEditor };
+const noteWithEmptyEditor = () => {
+  return new NoteModel(emptySerializedEditorState(), EDITOR_NAME, [], []);
+};
+
+export {
+  editorStateFromText,
+  emptySerializedEditorState,
+  emptyEditorState,
+  noteWithEmptyEditor
+};

--- a/src/lib/note/Note.js
+++ b/src/lib/note/Note.js
@@ -64,8 +64,12 @@ export default class Note {
     loadNoteContent(
       this,
       data => {
-        const cont = data ? JSON.parse(data) : emptySerializedEditorState();
-        this.setContent(cont);
+        if (data) {
+          this.content = JSON.parse(data);
+        } else {
+          this.setContent(emptySerializedEditorState());
+        }
+
         callback(this.content);
       },
       onFailure

--- a/src/lib/note/Note.js
+++ b/src/lib/note/Note.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import uuidv4 from "uuid/v4";
 import { loadNoteContent } from "../io";
 import { serializePreview, renderPreview as renderPre } from "../preview";
+import { emptySerializedEditorState } from "../editor/util";
 
 export default class Note {
   /**
@@ -63,7 +64,8 @@ export default class Note {
     loadNoteContent(
       this,
       data => {
-        this.content = JSON.parse(data);
+        const cont = data ? JSON.parse(data) : emptySerializedEditorState();
+        this.setContent(cont);
         callback(this.content);
       },
       onFailure
@@ -88,9 +90,9 @@ export default class Note {
     return renderPre(this.preview);
   };
 
-  setContent = content => {
+  setContent = serializedState => {
     const cont = {};
-    cont[this.mutationName] = content;
+    cont[this.mutationName] = serializedState;
     this.content = cont;
     return this.content;
   };


### PR DESCRIPTION
Fixes a bug where saving or deleting a note after an error would cause the app to error out with something like:

```
Failed to parse parse json on character 'u'
```

This was happening because if nothing got saved, it would load an `undefined` as the string and then try to parse the string `undefined` for json. 

So now there's a check. 