### PR TITLE
Implement stacking adding and deleting focus

### DIFF
--- a/src/lib/note/NoteView.js
+++ b/src/lib/note/NoteView.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Card, Container } from "../ui";
 import { Editor } from "../editor";
-import { selectNote, deleteNote } from "../../redux/actions";
+import { deleteNote } from "../../redux/actions";
 
 const DeleteButton = styled.button`
   float: right;
@@ -26,7 +26,6 @@ class NoteView extends React.Component {
       return;
     }
     this.props.dispatch(deleteNote(this.props.note));
-    this.props.dispatch(selectNote(null));
   };
 
   render() {

--- a/src/lib/note/NoteView.js
+++ b/src/lib/note/NoteView.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Card, Container } from "../ui";
 import { Editor } from "../editor";
-import { deleteNote } from "../../redux/actions";
+import { deleteNote, deleteNoteAndChangeSelection } from "../../redux/actions";
 
 const DeleteButton = styled.button`
   float: right;
@@ -25,7 +25,7 @@ class NoteView extends React.Component {
     if (this.props.note === null) {
       return;
     }
-    this.props.dispatch(deleteNote(this.props.note));
+    this.props.dispatch(deleteNoteAndChangeSelection(this.props.note));
   };
 
   render() {

--- a/src/lib/note/NoteView.js
+++ b/src/lib/note/NoteView.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Card, Container } from "../ui";
 import { Editor } from "../editor";
-import { deleteNote, deleteNoteAndChangeSelection } from "../../redux/actions";
+import { deleteNoteAndChangeSelection } from "../../redux/actions";
 
 const DeleteButton = styled.button`
   float: right;

--- a/src/lib/note/index.js
+++ b/src/lib/note/index.js
@@ -1,4 +1,4 @@
-import NoteModel from "./Note.js";
+import NoteModel from "./Note";
 import Attribute from "./Attribute.js";
 import Tag from "./Tag.js";
 

--- a/src/lib/note/test/util.test.js
+++ b/src/lib/note/test/util.test.js
@@ -1,0 +1,25 @@
+import { noteArrayToDict, noteDictToArray, newNote } from "../util";
+import NoteModel from "../Note";
+
+test("noteArrayToDict preserves a collection of notes as NoteModel", () => {
+  const notes = [newNote(), newNote(), newNote()];
+  const dict = noteArrayToDict(notes);
+  expect(dict[notes[0].uuid] instanceof NoteModel).toBe(true);
+});
+
+test("noteDictToArray correctly orders some notes", () => {
+  const notes = [newNote(), newNote(), newNote()];
+  const dict = noteArrayToDict(notes);
+  const arr = noteDictToArray(dict);
+  expect(arr[0].uuid === dict[arr[0].uuid].uuid).toBe(true);
+  expect(arr[1].uuid === dict[arr[1].uuid].uuid).toBe(true);
+  expect(arr[2].uuid === dict[arr[2].uuid].uuid).toBe(true);
+});
+
+test("newNote creates a new note model", () => {
+  expect(newNote("foo") instanceof NoteModel).toBe(true);
+});
+
+test("newNote creates a note model even when empty", () => {
+  expect(newNote() instanceof NoteModel).toBe(true);
+});

--- a/src/lib/note/util.js
+++ b/src/lib/note/util.js
@@ -1,0 +1,45 @@
+import { ContentState, EditorState } from "draft-js";
+import { serializeContent } from "../editor/EditorSerializer";
+import NoteModel from "./Note";
+
+/**
+ * Creates a basic NoteModel with some text
+ * @param {String} text
+ * @return {NoteModel}
+ */
+export const newNote = text => {
+  return new NoteModel(
+    serializeContent(
+      text
+        ? EditorState.createWithContent(ContentState.createFromText(text))
+        : EditorState.createEmpty()
+    ),
+    "BaseEditor",
+    [],
+    [],
+    []
+  );
+};
+
+/**
+ * Converts a note array to a note dictionary
+ */
+export const noteArrayToDict = notes => {
+  const dict = {};
+  notes.forEach(note => {
+    dict[note.uuid] = note;
+  });
+  return dict;
+};
+
+/**
+ * Converts a note dictionary to an array.
+ * @param {Dictionary} noteDict
+ */
+export const noteDictToArray = noteDict => {
+  const noteList = [];
+  for (const uuid in noteDict) {
+    noteList.push(noteDict[uuid]);
+  }
+  return noteList;
+};

--- a/src/lib/sidebar/NoteList.js
+++ b/src/lib/sidebar/NoteList.js
@@ -4,6 +4,7 @@ import { loadNotes } from "../../redux/actions";
 import NoteListItem from "./NoteListItem.js";
 import { Menu, MenuCardList, MenuItem } from "../ui/Menu";
 import { allNotes } from "../../redux/selectors";
+import { noteDictToArray } from "../note/util";
 
 const BumpedDownMenu = Menu.extend`
   padding-top: ${props => props.theme.spacing.header};
@@ -19,11 +20,9 @@ class NoteList extends React.Component {
   }
 
   render() {
-    const noteList = [];
-    for (const uuid in this.props.allNotes) {
-      const note = this.props.allNotes[uuid];
-      noteList.push(<NoteListItem key={note.uuid} note={note} />);
-    }
+    const noteList = noteDictToArray(this.props.allNotes).map(note => (
+      <NoteListItem key={note.uuid} note={note} />
+    ));
 
     return (
       <BumpedDownMenu>

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -19,6 +19,7 @@ export const SET_EDITOR_STATE = "SET_EDITOR_STATE";
 export const SET_TOAST = "SET_TOAST";
 export const UPDATE_NOTE = "UPDATE_NOTE";
 export const DELETE_NOTE = "DELETE_NOTE";
+export const BUMP_NOTE = "BUMP_NOTE";
 
 /**
  * Other constants
@@ -106,4 +107,15 @@ export function newNote(note) {
 export function deleteNote(note) {
   deleteN(note);
   return { type: DELETE_NOTE, note };
+}
+
+export function bumpNoteSelection() {
+  return { type: BUMP_NOTE };
+}
+
+export function deleteNoteAndChangeSelection(note) {
+  return dispatch => {
+    dispatch(bumpNoteSelection());
+    dispatch(deleteNote(note));
+  };
 }

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -13,12 +13,12 @@ import {
   DELETE_NOTE
 } from "../actions";
 import {
-  notesToDict,
   emptyEditorState,
   updateNoteInAllNotes,
   removeNoteFromAllNotes,
-  pickNoteFromAllNotes
+  pickPreviousNoteInList
 } from "../utils";
+import { noteArrayToDict } from "../../lib/note/util";
 
 function app(state = {}, action) {
   switch (action.type) {
@@ -57,16 +57,11 @@ function notes(
     case RECEIVED_NOTES:
       return Object.assign({}, state, {
         isLoadingNotes: false,
-        allNotes: notesToDict(action.notes)
+        allNotes: noteArrayToDict(action.notes)
       });
     case SELECT_NOTE:
       if (action.note === state.selectedNote) {
         return state;
-      }
-      if (action.note === null) {
-        return Object.assign({}, state, {
-          selectedNote: pickNoteFromAllNotes(state.allNotes)
-        });
       }
       return Object.assign({}, state, {
         selectedNote: action.note,
@@ -88,10 +83,17 @@ function notes(
       return Object.assign({}, state, {
         allNotes: updateNoteInAllNotes(action.note, state.allNotes)
       });
-    case DELETE_NOTE:
+    case DELETE_NOTE: {
+      const newSelectedNote = pickPreviousNoteInList(
+        state.allNotes,
+        state.selectedNote
+      );
+
       return Object.assign({}, state, {
+        selectedNote: newSelectedNote,
         allNotes: removeNoteFromAllNotes(action.note, state.allNotes)
       });
+    }
     default:
       return state;
   }

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -10,7 +10,8 @@ import {
   SET_TOAST,
   SET_EDITOR_STATE,
   UPDATE_NOTE,
-  DELETE_NOTE
+  DELETE_NOTE,
+  BUMP_NOTE
 } from "../actions";
 import {
   emptyEditorState,
@@ -83,17 +84,20 @@ function notes(
       return Object.assign({}, state, {
         allNotes: updateNoteInAllNotes(action.note, state.allNotes)
       });
-    case DELETE_NOTE: {
+    case BUMP_NOTE: {
       const newSelectedNote = pickPreviousNoteInList(
         state.allNotes,
         state.selectedNote
       );
-
       return Object.assign({}, state, {
-        selectedNote: newSelectedNote,
-        allNotes: removeNoteFromAllNotes(action.note, state.allNotes)
+        selectedNote: newSelectedNote
       });
     }
+    case DELETE_NOTE:
+      return Object.assign({}, state, {
+        allNotes: removeNoteFromAllNotes(action.note, state.allNotes)
+      });
+
     default:
       return state;
   }

--- a/src/redux/test/redux.test.js
+++ b/src/redux/test/redux.test.js
@@ -1,0 +1,19 @@
+import configureStore from "../configureStore";
+import { noteArrayToDict, newNote } from "../../lib/note/util";
+import { deleteNote } from "../actions";
+
+const selectedNote = newNote();
+const noteArr = [selectedNote, newNote(), newNote()];
+const store = configureStore({
+  notes: {
+    allNotes: noteArrayToDict(noteArr),
+    selectedNote: selectedNote
+  }
+});
+
+test("deleting a note will change the selectedNote to the next note", () => {
+  store.dispatch(deleteNote(selectedNote));
+  expect(store.getState().notes.selectedNote.uuid === noteArr[1].uuid).toBe(
+    true
+  );
+});

--- a/src/redux/test/redux.test.js
+++ b/src/redux/test/redux.test.js
@@ -1,6 +1,6 @@
 import configureStore from "../configureStore";
 import { noteArrayToDict, newNote } from "../../lib/note/util";
-import { deleteNote } from "../actions";
+import { deleteNoteAndChangeSelection } from "../actions";
 
 const selectedNote = newNote();
 const noteArr = [selectedNote, newNote(), newNote()];
@@ -12,7 +12,7 @@ const store = configureStore({
 });
 
 test("deleting a note will change the selectedNote to the next note", () => {
-  store.dispatch(deleteNote(selectedNote));
+  store.dispatch(deleteNoteAndChangeSelection(selectedNote));
   expect(store.getState().notes.selectedNote.uuid === noteArr[1].uuid).toBe(
     true
   );

--- a/src/redux/utils/index.js
+++ b/src/redux/utils/index.js
@@ -1,13 +1,6 @@
 import { EditorState } from "draft-js";
 import _ from "lodash";
-
-export const notesToDict = notes => {
-  const dict = {};
-  notes.forEach(note => {
-    dict[note.uuid] = note;
-  });
-  return dict;
-};
+import { noteDictToArray } from "../../lib/note/util";
 
 export const updateNote = (note, notesDict) => {
   notesDict[note.uuid] = note;
@@ -24,13 +17,39 @@ export const emptyEditorState = () => {
   return EditorState.createEmpty();
 };
 
-export const pickNoteFromAllNotes = allNotes => {
-  const keys = Object.keys(allNotes);
-  if (keys.length === 0) {
+export const indexOfNoteInArray = (noteArr, note) => {
+  return noteArr.map(n => n.uuid).indexOf(note.uuid);
+};
+
+export const pickPreviousNoteInList = (allNotes, selectedNote) => {
+  const noteArr = noteDictToArray(allNotes);
+
+  // Don't return anything if we have no other notes to pick from
+  if (noteArr.length === 0 || noteArr.length === 1) {
     return null;
   }
 
-  return allNotes[keys[0]];
+  let index = indexOfNoteInArray(noteArr, selectedNote);
+
+  // Just make sure we're not doing anything screwy
+  if (index === -1) {
+    throw new Error(
+      `pickPreviousNoteInList called with a note that doesn't exist. Selected note is: ${
+        selectedNote
+      }. Did you try to select a note that you deleted somehow? This may happen if you call 
+      a "deleteNote" action before a "selectNote" action.
+      `
+    );
+  }
+
+  // If select the item "up", do that, otherwise go down.
+  if (index > 0) {
+    index -= 1;
+  } else {
+    index += 1;
+  }
+
+  return noteArr[index];
 };
 
 export const updateNoteInAllNotes = (note, allNotes) => {

--- a/src/redux/utils/test/utils.test.js
+++ b/src/redux/utils/test/utils.test.js
@@ -1,40 +1,23 @@
 import {
-  notesToDict,
-  pickNoteFromAllNotes,
+  pickPreviousNoteInList,
   removeNoteFromAllNotes,
-  updateNoteInAllNotes
+  updateNoteInAllNotes,
+  indexOfNoteInArray
 } from "../index";
-import { NoteModel } from "../../../lib/note";
-import { ContentState, EditorState } from "draft-js";
-import { serializeContent } from "../../../lib/editor/EditorSerializer";
-
-const newNote = () =>
-  new NoteModel(
-    serializeContent(
-      EditorState.createWithContent(ContentState.createFromText("Hello"))
-    ),
-    "BaseEditor",
-    [],
-    [],
-    []
-  );
-
-test("notesToDict preserves a collection of notes as NoteModel", () => {
-  const notes = [newNote(), newNote(), newNote()];
-  const dict = notesToDict(notes);
-  expect(dict[notes[0].uuid] instanceof NoteModel).toBe(true);
-});
+import { newNote, noteArrayToDict } from "../../../lib/note/util";
+import NoteModel from "../../../lib/note/Note";
 
 test("updateNoteInAllNotes doesn't change NoteModel types", () => {
   const notes = [newNote(), newNote(), newNote()];
-  const dict = notesToDict(notes);
+  const dict = noteArrayToDict(notes);
+
   const newAllNotes = updateNoteInAllNotes(notes[0], dict);
   expect(newAllNotes[notes[0].uuid] instanceof NoteModel).toBe(true);
 });
 
 test("removeNoteFromAllNotes doesn't change NoteModel types", () => {
   const notes = [newNote(), newNote(), newNote()];
-  const allNotes = notesToDict(notes);
+  const allNotes = noteArrayToDict(notes);
 
   const newAllNotes = removeNoteFromAllNotes(notes[0], allNotes);
   expect(newAllNotes[notes[1].uuid] instanceof NoteModel);
@@ -43,19 +26,30 @@ test("removeNoteFromAllNotes doesn't change NoteModel types", () => {
 
 test("pickNotesFromAllNotes preserves NoteModel type", () => {
   const notes = [newNote(), newNote(), newNote()];
-  const allNotes = notesToDict(notes);
+  const allNotes = noteArrayToDict(notes);
 
   // Check First note is good
-  const note = pickNoteFromAllNotes(allNotes);
+  const note = pickPreviousNoteInList(allNotes, notes[0]);
   expect(note instanceof NoteModel).toBe(true);
 
   // Remove that note and check again - 2nd note
   removeNoteFromAllNotes(note, allNotes);
-  const note2 = pickNoteFromAllNotes(allNotes);
+  const note2 = pickPreviousNoteInList(allNotes, notes[0]);
   expect(note2 instanceof NoteModel);
 
   // Remove that note and check again - 3rd note
   removeNoteFromAllNotes(note, allNotes);
-  const note3 = pickNoteFromAllNotes(allNotes);
+  const note3 = pickPreviousNoteInList(allNotes, notes[0]);
   expect(note3 instanceof NoteModel);
+});
+
+test("indexOfNoteInArray can find a note's index", () => {
+  const notes = [newNote(), newNote()];
+  expect(indexOfNoteInArray(notes, notes[0])).toBe(0);
+  expect(indexOfNoteInArray(notes, notes[1])).toBe(1);
+});
+
+test("indexOfNoteInArray can return -1 if there's no note", () => {
+  const notes = [newNote(), newNote()];
+  expect(indexOfNoteInArray(notes, newNote())).toBe(-1);
 });


### PR DESCRIPTION
This PR adds "Stacking" sidebar item focus transitions. 

"Focus" in this context means the primary color border around the preview cards in the side bar. It also means the `selectedNote` in the redux state. 

It would be nice if when we deleted a note, that focus transitioned to another item similar to how Powerpoint or Evernote do. I'm not really sure what that's called so I've decided to refer to that transition style as "stacking".

Here's a gif of what it looks like: 

![stacking notes](https://user-images.githubusercontent.com/5942769/33235808-f26cb990-d1f5-11e7-8cfa-9b23970dd7b0.gif)

The general rules are: 
* If the state can transition "upwards", do so.
* Otherwise, transition downwards. 
* If there's any notes at all, something should be selected. 

